### PR TITLE
Make the 'version mismatch' error clearer

### DIFF
--- a/SysBot.Pokemon.Discord/Commands/Bots/TradeModule.cs
+++ b/SysBot.Pokemon.Discord/Commands/Bots/TradeModule.cs
@@ -66,7 +66,7 @@ namespace SysBot.Pokemon.Discord
                 pkm = EntityConverter.ConvertToType(pkm, typeof(T), out _) ?? pkm;
                 if (pkm is not T pk || !la.Valid)
                 {
-                    var reason = result == "Timeout" ? $"That {spec} set took too long to generate." : result == "VersionMismatch" ? "Request refused: version mismatch." : $"I wasn't able to create a {spec} from that set.";
+                    var reason = result == "Timeout" ? $"That {spec} set took too long to generate." : result == "VersionMismatch" ? "Request refused: PKHeX and Auto-Legality Mod version mismatch." : $"I wasn't able to create a {spec} from that set.";
                     var imsg = $"Oops! {reason}";
                     if (result == "Failed")
                         imsg += $"\n{AutoLegalityWrapper.GetLegalizationHint(template, sav, pkm)}";

--- a/SysBot.Pokemon.Discord/Helpers/AutoLegalityExtensionsDiscord.cs
+++ b/SysBot.Pokemon.Discord/Helpers/AutoLegalityExtensionsDiscord.cs
@@ -25,7 +25,7 @@ namespace SysBot.Pokemon.Discord
                 var spec = GameInfo.Strings.Species[template.Species];
                 if (!la.Valid)
                 {
-                    var reason = result == "Timeout" ? $"That {spec} set took too long to generate." : result == "VersionMismatch" ? "Request refused: version mismatch." : $"I wasn't able to create a {spec} from that set.";
+                    var reason = result == "Timeout" ? $"That {spec} set took too long to generate." : result == "VersionMismatch" ? "Request refused: PKHeX and Auto-Legality Mod version mismatch." : $"I wasn't able to create a {spec} from that set.";
                     var imsg = $"Oops! {reason}";
                     if (result == "Failed")
                         imsg += $"\n{AutoLegalityWrapper.GetLegalizationHint(template, sav, pkm)}";


### PR DESCRIPTION
People are trying to mismatch latest dev cores and don't understand this error message without it saying what exactly is mismatched.